### PR TITLE
Added python plotting tool for fits file for CoFeS plots

### DIFF
--- a/cofes_vis.py
+++ b/cofes_vis.py
@@ -1,29 +1,35 @@
-"""
+import matplotlib.pyplot as plt
+import aplpy
+import numpy as np
 
-Notes from playing with this in ipython. following this idea should work
-
-In [15]: import matplotlib.pyplot as mpl
-
-In [16]: import matplotlib
-
-In [17]: matplotlib.interactive(True)
-
-In [18]: fig = mpl.figure()
-
-In [19]: fig.add_subplot(4,3,1)
-Out[19]: <matplotlib.axes._subplots.AxesSubplot at 0x117291358>
-
-In [20]: f1 = aplpy.FITSFigure("CoFeS20170202T061644.8_073_sci.fits",figure=fig,subplot=(4,3,1))
-WARNING: No WCS information found in header - using pixel coordinates [aplpy.header]
-
-In [21]: f1.show_grayscale()
-INFO: Auto-setting vmin to -4.667e+01 [aplpy.core]
-INFO: Auto-setting vmax to  4.702e+02 [aplpy.core]
-
-In [22]: f2 = aplpy.FITSFigure("CoFeS20170202T061644.8_085_sci.fits",figure=fig,subplot=(4,3,2))
-WARNING: No WCS information found in header - using pixel coordinates [aplpy.header]
-
-In [23]: f2.show_grayscale()
-INFO: Auto-setting vmin to -6.725e+01 [aplpy.core]
-INFO: Auto-setting vmax to  6.930e+02 [aplpy.core]
-"""
+def cofes_plots(filename_array, outfile_name):
+    """
+    filename_array is an array-like object that contains the filenames
+    of fits files to plot. The output plot will be the shape of the input array.
+    outfile is the output file name including the extension, such as out.fits.
+    """
+    filename_array = np.array(filename_array)
+    assert filename_array.ndim < 3, "filename_array has more than two dimensions. I can't plot that!"
+    assert filename_array.size > 0, "filename_array has size zero. There's nothing there to plot!"
+    if filename_array.ndim == 1:
+        rows = 1
+        cols = filename_array.shape[0]
+    else:
+        rows = filename_array.shape[0]
+        cols = filename_array.shape[0]
+    
+    fig = plt.figure()
+    for i,fitsfile in enumerate(filename_array.flatten()):
+        #robust against files not existing
+        try:
+            fitsplot = aplpy.FITSFigure(fitsfile,figure=fig,subplot=(rows,cols,i+1))
+            fitsplot.show_grayscale()
+        except IOError:
+            print(fitsfile, "not found. Skipping...")
+    
+    fig.savefig(outfile_name)
+    
+    
+    
+    
+    

--- a/cofes_vis.py
+++ b/cofes_vis.py
@@ -1,0 +1,29 @@
+"""
+
+Notes from playing with this in ipython. following this idea should work
+
+In [15]: import matplotlib.pyplot as mpl
+
+In [16]: import matplotlib
+
+In [17]: matplotlib.interactive(True)
+
+In [18]: fig = mpl.figure()
+
+In [19]: fig.add_subplot(4,3,1)
+Out[19]: <matplotlib.axes._subplots.AxesSubplot at 0x117291358>
+
+In [20]: f1 = aplpy.FITSFigure("CoFeS20170202T061644.8_073_sci.fits",figure=fig,subplot=(4,3,1))
+WARNING: No WCS information found in header - using pixel coordinates [aplpy.header]
+
+In [21]: f1.show_grayscale()
+INFO: Auto-setting vmin to -4.667e+01 [aplpy.core]
+INFO: Auto-setting vmax to  4.702e+02 [aplpy.core]
+
+In [22]: f2 = aplpy.FITSFigure("CoFeS20170202T061644.8_085_sci.fits",figure=fig,subplot=(4,3,2))
+WARNING: No WCS information found in header - using pixel coordinates [aplpy.header]
+
+In [23]: f2.show_grayscale()
+INFO: Auto-setting vmin to -6.725e+01 [aplpy.core]
+INFO: Auto-setting vmax to  6.930e+02 [aplpy.core]
+"""

--- a/cofes_vis.py
+++ b/cofes_vis.py
@@ -1,6 +1,8 @@
 import matplotlib.pyplot as plt
 import aplpy
 import numpy as np
+import os
+from glob import glob
 
 def cofes_plots(filename_array, outfile_name, vmin=-15, vmax=25):
     """
@@ -38,6 +40,36 @@ def cofes_plots(filename_array, outfile_name, vmin=-15, vmax=25):
     fig.savefig(outfile_name)
     
     
+def cofes_4x4_plots(dir = "", outfile_name = 'CoFeS_plots.png'):
+    """
+    dir is a string containing the directory with the CoFeS files you wish
+    to plot. If its the local directory you can leave it as an empty string
     
+    outfile_name is a string with the output file name. This will be placed
+    in the dir directory
+    
+    the ifu order is
+    073 083 093 103
+    074 084 094 104
+    075 085 095 105
+    076 086 096 106
+
+    """
+    ifunums = np.array([['073', '083', '093', '103'],
+                        ['074', '084', '094', '104'],
+                        ['075', '085', '095', '105'],
+                        ['076', '086', '096', '106']])
+    original_dir = os.getcwd()
+    if dir != "":
+        os.chdir(dir)
+    cofes_files = glob("CoFeS*.fits")
+    prefix = cofes_files[0].split('_')[0]
+    filename_list = []
+    for i in ifunums.flatten():
+        filename_list.append(prefix + '_' + i + '_sci.fits')
+    filename_array = np.array(filename_list)
+    filename_array = filename_array.reshape(ifunums.shape[0], ifunums.shape[1])
+    cofes_plots(filename_array, outfile_name)
+    os.chdir(original_dir)
     
     

--- a/cofes_vis.py
+++ b/cofes_vis.py
@@ -2,11 +2,16 @@ import matplotlib.pyplot as plt
 import aplpy
 import numpy as np
 
-def cofes_plots(filename_array, outfile_name):
+def cofes_plots(filename_array, outfile_name, vmin=-15, vmax=25):
     """
     filename_array is an array-like object that contains the filenames
     of fits files to plot. The output plot will be the shape of the input array.
+    
     outfile is the output file name including the extension, such as out.fits.
+    
+    vmin and vmax set the stretch for the images. They are in units of counts;
+    Pixels with vmin and below counts are black. Pixels with vmax and above counts
+    are white. 
     """
     filename_array = np.array(filename_array)
     assert filename_array.ndim < 3, "filename_array has more than two dimensions. I can't plot that!"
@@ -23,7 +28,10 @@ def cofes_plots(filename_array, outfile_name):
         #robust against files not existing
         try:
             fitsplot = aplpy.FITSFigure(fitsfile,figure=fig,subplot=(rows,cols,i+1))
-            fitsplot.show_grayscale()
+            fitsplot.hide_axis_labels()
+            fitsplot.hide_tick_labels()
+            fitsplot.show_grayscale(vmin=vmin, vmax=vmax)
+            
         except IOError:
             print(fitsfile, "not found. Skipping...")
     


### PR DESCRIPTION
added visualization tool for CoFeS fits images in python per Karl's request. Note that this does require [aplpy](https://aplpy.github.io/), which is easy to install via pip. 